### PR TITLE
feat: add task attributes and sorting

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -69,4 +69,20 @@ html, body, #root {
   padding: 0.5rem;
   border-radius: 4px;
   margin-bottom: 0.5rem;
+  position: relative;
+}
+
+.task-meta {
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.modal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  z-index: 10;
 }

--- a/src/components/ListView.jsx
+++ b/src/components/ListView.jsx
@@ -1,14 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import TaskNode from './TaskNode.jsx';
 import useTaskStore from '../store.js';
 
+const priorityOrder = { high: 0, medium: 1, low: 2 };
+const statusOrder = { 'To-Do': 0, 'In-Progress': 1, Done: 2 };
+
 export default function ListView() {
   const tasks = useTaskStore((s) => s.tasks);
+  const [sortBy, setSortBy] = useState('none');
+
+  const sorted = [...tasks].sort((a, b) => {
+    if (sortBy === 'priority') {
+      return (priorityOrder[a.priority] ?? 99) - (priorityOrder[b.priority] ?? 99);
+    }
+    if (sortBy === 'status') {
+      return (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99);
+    }
+    return 0;
+  });
+
   return (
     <section className="list-view">
       <h2>Task List</h2>
+      <label>
+        Sort by:
+        <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+          <option value="none">None</option>
+          <option value="priority">Priority</option>
+          <option value="status">Status</option>
+        </select>
+      </label>
       <div>
-        {tasks.map((t) => (
+        {sorted.map((t) => (
           <TaskNode key={t.id} id={t.id} title={t.title} />
         ))}
       </div>

--- a/src/components/TaskNode.jsx
+++ b/src/components/TaskNode.jsx
@@ -1,21 +1,91 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Timer from './Timer.jsx';
 import useTaskStore from '../store.js';
 
-// Displays a task title with an attached timer
+const priorityColors = {
+  high: 'salmon',
+  medium: 'orange',
+  low: 'lightgreen',
+};
+
+// Displays a task title with timer and editable metadata
 export default function TaskNode({ id, title = 'New Task' }) {
   const addTask = useTaskStore((s) => s.addTask);
+  const updateTask = useTaskStore((s) => s.updateTask);
   const taskId = useRef(id || Date.now().toString());
+  const task = useTaskStore((s) => s.tasks.find((t) => t.id === taskId.current));
+  const [open, setOpen] = useState(false);
 
   // ensure task exists in the store
   useEffect(() => {
     addTask(title, taskId.current);
   }, [addTask, title]);
 
+  const t = task || { title, priority: 'medium', status: 'To-Do', category: '', dueDate: '' };
+
   return (
-    <div className="task-node">
-      <h3>{title}</h3>
+    <div
+      className="task-node"
+      style={{ border: `2px solid ${priorityColors[t.priority] || 'gray'}` }}
+    >
+      <h3 onClick={() => setOpen(true)}>{t.title}</h3>
+      <div className="task-meta">
+        <span>{t.status}</span>
+        {t.category && <span> | {t.category}</span>}
+        {t.dueDate && <span> | {new Date(t.dueDate).toLocaleDateString()}</span>}
+      </div>
       <Timer taskId={taskId.current} />
+      {open && (
+        <div className="modal">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const form = e.target;
+              updateTask(taskId.current, {
+                title: form.title.value,
+                priority: form.priority.value,
+                status: form.status.value,
+                category: form.category.value,
+                dueDate: form.dueDate.value,
+              });
+              setOpen(false);
+            }}
+          >
+            <label>
+              Title
+              <input name="title" defaultValue={t.title} />
+            </label>
+            <label>
+              Priority
+              <select name="priority" defaultValue={t.priority}>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
+            </label>
+            <label>
+              Status
+              <select name="status" defaultValue={t.status}>
+                <option value="To-Do">To-Do</option>
+                <option value="In-Progress">In-Progress</option>
+                <option value="Done">Done</option>
+              </select>
+            </label>
+            <label>
+              Category
+              <input name="category" defaultValue={t.category} />
+            </label>
+            <label>
+              Due Date
+              <input type="date" name="dueDate" defaultValue={t.dueDate?.slice(0, 10)} />
+            </label>
+            <button type="submit">Save</button>
+            <button type="button" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+          </form>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/__tests__/components.test.jsx
+++ b/src/components/__tests__/components.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { describe, expect, test, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import MindMap from '../MindMap.jsx';
@@ -6,9 +6,13 @@ import ListView from '../ListView.jsx';
 import RealityView from '../RealityView.jsx';
 import TaskNode from '../TaskNode.jsx';
 import Toolbar from '../Toolbar.jsx';
+import useTaskStore from '../../store.js';
 
 describe('UI components', () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    useTaskStore.setState({ tasks: [] });
+    cleanup();
+  });
   test('MindMap renders heading', () => {
     render(<MindMap />);
     expect(screen.getByRole('heading', { name: /mind map/i })).toBeInTheDocument();
@@ -34,5 +38,17 @@ describe('UI components', () => {
     expect(screen.getByText('Add Task')).toBeInTheDocument();
     expect(screen.getByText('Download Data')).toBeInTheDocument();
     expect(screen.getByText('Switch View')).toBeInTheDocument();
+  });
+
+  test('ListView sorts by priority', () => {
+    const addTask = useTaskStore.getState().addTask;
+    addTask('Low', '1', { priority: 'low' });
+    addTask('High', '2', { priority: 'high' });
+    render(<ListView />);
+    fireEvent.change(screen.getByLabelText(/sort by/i), {
+      target: { value: 'priority' },
+    });
+    const headings = screen.getAllByRole('heading', { level: 3 });
+    expect(headings[0]).toHaveTextContent('High');
   });
 });

--- a/src/store.js
+++ b/src/store.js
@@ -6,16 +6,33 @@ const useTaskStore = create(
   persist(
     (set, get) => ({
       tasks: [],
-      addTask: (title, id) => set((state) => {
-        const taskId = id || Date.now().toString();
-        if (state.tasks.find((t) => t.id === taskId)) return state; // avoid duplicates
-        return {
-          tasks: [
-            ...state.tasks,
-            { id: taskId, title, elapsed: 0, isRunning: false, startTime: null },
-          ],
-        };
-      }),
+      addTask: (title, id, attrs = {}) =>
+        set((state) => {
+          const taskId = id || Date.now().toString();
+          if (state.tasks.find((t) => t.id === taskId)) return state; // avoid duplicates
+          return {
+            tasks: [
+              ...state.tasks,
+              {
+                id: taskId,
+                title,
+                elapsed: 0,
+                isRunning: false,
+                startTime: null,
+                priority: attrs.priority || 'medium',
+                status: attrs.status || 'To-Do',
+                category: attrs.category || '',
+                dueDate: attrs.dueDate || null,
+              },
+            ],
+          };
+        }),
+      updateTask: (id, updates) =>
+        set((state) => ({
+          tasks: state.tasks.map((t) =>
+            t.id === id ? { ...t, ...updates } : t
+          ),
+        })),
       startTimer: (id) =>
         set((state) => ({
           tasks: state.tasks.map((t) =>


### PR DESCRIPTION
## Summary
- extend task store with priority, status, category and due date fields and update API
- enhance TaskNode with colored border, metadata display and modal editor
- allow ListView to sort tasks by priority or status with new select control
- add basic styles and tests for priority sorting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a09d2eb5a083288e34fad5da71c0af