### PR TITLE
Add stubs for collaboration and AI features

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,0 +1,14 @@
+// Placeholder stubs for future AI-powered task assistance.
+// Functions here will later integrate with external AI services.
+
+export async function getTaskSplitSuggestions(task) {
+  // TODO: Replace with API call to fetch subtasks.
+  console.warn('getTaskSplitSuggestions is a stub.', task);
+  return [];
+}
+
+export async function getDueDateRecommendation(task) {
+  // TODO: Replace with API call to suggest a due date.
+  console.warn('getDueDateRecommendation is a stub.', task);
+  return null;
+}

--- a/src/collaboration.js
+++ b/src/collaboration.js
@@ -1,0 +1,28 @@
+// Placeholder utilities for future real-time collaboration features.
+// Currently logs actions and does not perform any network activity.
+
+let socket = null;
+
+export function connectToCollaborationServer(roomId = 'default-room') {
+  // TODO: Replace with real WebSocket connection logic.
+  console.warn('connectToCollaborationServer is a stub.', roomId);
+  socket = null;
+}
+
+export function broadcastTaskUpdate(task) {
+  // TODO: Send task updates to the collaboration server.
+  console.warn('broadcastTaskUpdate is a stub.', task);
+  if (!socket) return;
+  try {
+    socket.send(JSON.stringify({ type: 'task:update', payload: task }));
+  } catch (err) {
+    console.error('WebSocket send failed:', err);
+  }
+}
+
+export function onRemoteTaskUpdate(handler) {
+  // TODO: Listen for updates from remote collaborators.
+  console.warn('onRemoteTaskUpdate is a stub.');
+  // Return a no-op unsubscribe function for now.
+  return () => {};
+}


### PR DESCRIPTION
## Summary
- scaffold WebSocket collaboration utilities
- stub AI suggestion functions for task splitting and due dates
- expose collaboration and AI stubs through task store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a06a0edc832889f28f312bb744e9