### PR TITLE
Add CI workflows for frontend and optional Python tracker

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,30 @@
+name: python-tracker
+
+on:
+  push:
+    paths:
+      - 'tracker/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: ${{ hashFiles('tracker/**') != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f tracker/requirements.txt ]; then pip install -r tracker/requirements.txt; fi
+          pip install pyinstaller
+      - name: Build with PyInstaller
+        run: |
+          pyinstaller tracker/main.py --onefile --name MindMirrorTracker
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mindmirror-tracker
+          path: dist/MindMirrorTracker

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -1,0 +1,47 @@
+name: frontend
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run test:components
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ This release migrates the project to a React + Vite setup.
 ```
 
 No legacy Python/Tkinter files are present in this version.
+
+## Deployment & Packaging
+
+- `.github/workflows/react.yml` installs dependencies, lints, runs tests, builds the Vite frontend and deploys the `dist/` folder to GitHub Pages.
+- `.github/workflows/python.yml` packages an optional Python tracker with PyInstaller when files exist under `tracker/`.
+
+The React build and Python binary can later be bundled together with frameworks like Electron or Tauri to produce a unified desktop application.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, test, build, and deploy Vite React app to GitHub Pages
- add optional Python tracker workflow using PyInstaller
- document deployment and packaging options

## Testing
- `npm run lint`
- `npm test`
- `npm run test:components`
- `npm run test:e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a508f65883288b7fbb30dc99c7d6